### PR TITLE
META-223 Unit test in a dependent module fails against 1.9.x

### DIFF
--- a/api/src/main/resources/ImportedPackage.hbm.xml
+++ b/api/src/main/resources/ImportedPackage.hbm.xml
@@ -26,7 +26,7 @@
 			length="64" />
 		<property name="description" type="java.lang.String" column="description"
 			length="256" />
-		<property name="importConfig" column="import_config">
+		<property name="importConfig" column="import_config" length="1024">
 			<type
 				name="org.openmrs.module.metadatasharing.api.db.hibernate.XMLSerializableType">
 				<param name="class">org.openmrs.module.metadatasharing.ImportConfig</param>


### PR DESCRIPTION
This allows me to get my module unit test working.

I haven't actually verified that this doesn't break things in the webapp (but I can't see how it would).
