### PR TITLE
META-356: Changed the tags to correct expected tags

### DIFF
--- a/omod/src/main/webapp/import/assessItem.jsp
+++ b/omod/src/main/webapp/import/assessItem.jsp
@@ -145,7 +145,7 @@
 						<c:if test="${not empty item.existing}">
 							<c:if test="${item.existingClassSimpleName != item.incomingClassSimpleName}">
 								<tr>
-									<td class="to_right"> <springform:form code="metadatasharing.type" /> </td>
+									<td class="to_right"> <spring:message code="metadatasharing.type" /> </td>
 									<td><span id="incomingType">${item.incomingClassSimpleName}</span></td>
 								</tr>
 							</c:if>
@@ -191,7 +191,7 @@
 							<c:if test="${not empty item.existing}">
 								<c:if test="${item.existingClassSimpleName != item.incomingClassSimpleName}">
 									<tr>
-										<td class="to_right"> <springform:form code="metadatasharing.type" /> </td>
+										<td class="to_right"> <spring:message code="metadatasharing.type" /> </td>
 										<td><span id="existingType">${item.existingClassSimpleName}</span></td>
 									</tr>
 								</c:if>


### PR DESCRIPTION
This fixes the incorrectly used tags <springform:form code="some property from message bundles"/>. I think these errors were introduced by the use of autocomplete feature during coding.