### PR TITLE
RA-1181 Release metadatasharing from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
-  
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: ./deploy.sh
+  on:
+    branch: release

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mvn org.openmrs.maven.plugins:openmrs-sdk-maven-plugin:3.2.1:setup-sdk -DbatchAnswers=n
+mvn org.openmrs.maven.plugins:openmrs-sdk-maven-plugin:3.2.1:release -DdefaultVersions -DbintrayUsername=$BINTRAY_USERNAME -DbintrayApiKey=$BINTRAY_API_KEY -DgithubUsername=$GITHUB_USERNAME -DgithubPassword=$GITHUB_PASSWORD


### PR DESCRIPTION
Before merging this, we need:
-release SDK
-fix the current problem described here [here](https://issues.openmrs.org/browse/RA-1180) in the comments
-test it. I could only check if travis triggered by new coomit on release branch runs the deploy script 