### PR TITLE
TRUNK-5699 Deprecate Attributable#findPossibleValues() and Attributable#getPossibleValues()

### DIFF
--- a/api-test/src/test/java/org/openmrs16/Concept.java
+++ b/api-test/src/test/java/org/openmrs16/Concept.java
@@ -1423,6 +1423,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @see org.openmrs.Attributable#findPossibleValues(java.lang.String)
 	 */
+	@Deprecated
 	public List<Concept> findPossibleValues(String searchText) {
 		List<Concept> concepts = new Vector<Concept>();
 		try {
@@ -1441,6 +1442,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @see org.openmrs.Attributable#getPossibleValues()
 	 */
+	@Deprecated
 	public List<Concept> getPossibleValues() {
 		try {
 			/*return Context.getConceptService().getConceptsByName("");*/

--- a/api-test/src/test/java/org/openmrs18/Concept.java
+++ b/api-test/src/test/java/org/openmrs18/Concept.java
@@ -1477,6 +1477,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @see org.openmrs.Attributable#findPossibleValues(java.lang.String)
 	 */
+	@Deprecated
 	public List<Concept> findPossibleValues(String searchText) {
 		/*List<Concept> concepts = new Vector<Concept>();
 		try {
@@ -1495,6 +1496,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @see org.openmrs.Attributable#getPossibleValues()
 	 */
+	@Deprecated
 	public List<Concept> getPossibleValues() {
 		/*try {
 			return Context.getConceptService().getConceptsByName("");


### PR DESCRIPTION
## Description of what I changed
Deprecated the methods `Attributable#findPossibleValues()` and `Attributable#getPossibleValues()`


## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5699