### PR TITLE
Remove bean definition for defaultAnnotationHandlerMapping

### DIFF
--- a/api-2.0/pom.xml
+++ b/api-2.0/pom.xml
@@ -16,7 +16,6 @@
 	<properties>
 		<openmrs.2.0.api.version>2.0.0-alpha</openmrs.2.0.api.version>
 	</properties>
-
 	<dependencies>
 		
 		<dependency>

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -21,13 +21,8 @@
   		    http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
 	<!-- Beans related to the web context -->
-	 
-	<!-- Annotation based controllers -->
-	<bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>
-	
 	<context:component-scan base-package="org.openmrs.module.metadatasharing.web.controller" />
 	
 	<bean id="multipartResolver"
 		class="org.springframework.web.multipart.commons.CommonsMultipartResolver" />
-		
 </beans>


### PR DESCRIPTION
https://issues.openmrs.org/browse/META-371
 Removed bean definition for defaultAnnotationHandlerMapping. This is due to spring version was upgraded to version 5 of openmrs core and bean definition defaultAnnotationHandlerMapping was deprecated. Note this is not a madate of just removing this class according to this https://issues.openmrs.org/browse/TRUNK-5722
    Am also still figuring out how this module will be dependant on the current version of openmrs core, Because, one, metadatasharing module still depends on spring version 3.0.5.release. Am i think it should be the same version of the updated spring version of which it depends on (spring version 5.0.4).Any help here
   However this didnot have any error so everything run successfull locally. Some guidance of how to make metadatashaing module to be able to depend on current spring version in openmrs core. cc @dkayiwa  @ibacher  @mozzy11  @Ruhanga thanks