### PR TITLE
META-379: fix PersistentBag and PersistentSortedMap conversion

### DIFF
--- a/api-1.9/src/main/java/org/openmrs/module/metadatasharing/serializer/converter/CollectionConverterCompatibility1_9.java
+++ b/api-1.9/src/main/java/org/openmrs/module/metadatasharing/serializer/converter/CollectionConverterCompatibility1_9.java
@@ -14,9 +14,9 @@
 package org.openmrs.module.metadatasharing.serializer.converter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -25,11 +25,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.hibernate.collection.PersistentCollection;
-import org.hibernate.collection.PersistentList;
-import org.hibernate.collection.PersistentMap;
-import org.hibernate.collection.PersistentSet;
-import org.hibernate.collection.PersistentSortedMap;
-import org.hibernate.collection.PersistentSortedSet;
 import org.openmrs.annotation.OpenmrsProfile;
 
 import com.thoughtworks.xstream.converters.ConverterLookup;
@@ -48,16 +43,18 @@ public class CollectionConverterCompatibility1_9 implements CollectionConverterC
 	public void marshal(Object source, HierarchicalStreamWriter writer,
 			MarshallingContext context, ConverterLookup converterLookup) {
 		
-		if (source instanceof PersistentList) {
-			source = new ArrayList((Collection) source);
-		} else if (source instanceof PersistentMap) {
-			source = new HashMap((Map) source);
-		} else if (source instanceof PersistentSortedMap) {
-			source = new TreeMap((SortedMap) source);
-		} else if (source instanceof PersistentSortedSet) {
-			source = new TreeSet((SortedSet) source);
-		} else if (source instanceof PersistentSet) {
-			source = new HashSet((Set) source);
+		if (source instanceof PersistentCollection) {
+			if (source instanceof List) {
+				source = new ArrayList((List) source);
+			} else if (source instanceof SortedMap) {
+				source = new TreeMap((SortedMap) source);
+			} else if (source instanceof Map) {
+				source = new HashMap((Map) source);
+			} else if (source instanceof SortedSet) {
+				source = new TreeSet((SortedSet) source);
+			} else if (source instanceof Set) {
+				source = new HashSet((Set) source);
+			}
 		}
 		
 		// delegate the collection to the approapriate converter

--- a/api-2.0/src/main/java/org/openmrs/module/metadatasharing/serializer/converter/CollectionConverterCompatibility2_0.java
+++ b/api-2.0/src/main/java/org/openmrs/module/metadatasharing/serializer/converter/CollectionConverterCompatibility2_0.java
@@ -14,9 +14,9 @@
 package org.openmrs.module.metadatasharing.serializer.converter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -24,11 +24,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import org.hibernate.collection.internal.PersistentList;
-import org.hibernate.collection.internal.PersistentMap;
-import org.hibernate.collection.internal.PersistentSet;
-import org.hibernate.collection.internal.PersistentSortedMap;
-import org.hibernate.collection.internal.PersistentSortedSet;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.openmrs.annotation.OpenmrsProfile;
 
@@ -48,16 +43,18 @@ public class CollectionConverterCompatibility2_0 implements CollectionConverterC
 	public void marshal(Object source, HierarchicalStreamWriter writer,
 			MarshallingContext context, ConverterLookup converterLookup) {
 		
-		if (source instanceof PersistentList) {
-			source = new ArrayList((Collection) source);
-		} else if (source instanceof PersistentMap) {
-			source = new HashMap((Map) source);
-		} else if (source instanceof PersistentSortedMap) {
-			source = new TreeMap((SortedMap) source);
-		} else if (source instanceof PersistentSortedSet) {
-			source = new TreeSet((SortedSet) source);
-		} else if (source instanceof PersistentSet) {
-			source = new HashSet((Set) source);
+		if (source instanceof PersistentCollection) {
+			if (source instanceof List) {
+				source = new ArrayList((List) source);
+			} else if (source instanceof SortedMap) {
+				source = new TreeMap((SortedMap) source);
+			} else if (source instanceof Map) {
+				source = new HashMap((Map) source);
+			} else if (source instanceof SortedSet) {
+				source = new TreeSet((SortedSet) source);
+			} else if (source instanceof Set) {
+				source = new HashSet((Set) source);
+			}
 		}
 		
 		// delegate the collection to the appropriate converter

--- a/api-test/src/test/java/org/openmrs/module/metadatasharing/serializer/converter/CollectionConverterCompatibility19Test.java
+++ b/api-test/src/test/java/org/openmrs/module/metadatasharing/serializer/converter/CollectionConverterCompatibility19Test.java
@@ -1,0 +1,155 @@
+package org.openmrs.module.metadatasharing.serializer.converter;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.ConverterLookup;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import org.hibernate.collection.PersistentBag;
+import org.hibernate.collection.PersistentList;
+import org.hibernate.collection.PersistentMap;
+import org.hibernate.collection.PersistentSet;
+import org.hibernate.collection.PersistentSortedMap;
+import org.hibernate.collection.PersistentSortedSet;
+import org.hibernate.engine.SessionImplementor;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+
+/**
+ * Tests if hibernate collections are converted properly
+ *
+ * @see CollectionConverterCompatibility1_9
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class CollectionConverterCompatibility19Test {
+	
+	@Mock
+	ConverterLookup converterLookup;
+	@Mock
+	Converter converter;
+	@Mock
+	HierarchicalStreamWriter writer;
+	@Mock
+	MarshallingContext context;
+	
+	@Mock
+	SessionImplementor session;
+	Integer key = 3;
+	Integer value = 2;
+	
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		when(converterLookup.lookupConverterForType(any(Class.class)))
+				.thenReturn(converter);
+	}
+	
+	@Test
+	public void marshal_PersistentList() {
+		PersistentList source = PowerMockito.mock(PersistentList.class);
+		when(source.toArray())
+				.thenReturn(new Object[]{value});
+		
+		new CollectionConverterCompatibility1_9().marshal(source, writer, context, converterLookup);
+		
+		verify(converterLookup).lookupConverterForType(ArrayList.class);
+		verify(converter).marshal(argThat(hasItem(value)),
+				same(writer), same(context));
+	}
+	
+	@Test
+	public void marshal_PersistentBag() {
+		PersistentBag source = PowerMockito.mock(PersistentBag.class);
+		when(source.toArray()).thenReturn(new Object[]{value});
+		
+		new CollectionConverterCompatibility1_9().marshal(source, writer, context, converterLookup);
+		
+		verify(converterLookup).lookupConverterForType(ArrayList.class);
+		verify(converter).marshal(argThat(hasItem(value)),
+				same(writer), same(context));
+	}
+	
+	@Test
+	public void marshal_PersistentSortedMap() {
+		SortedMap backingMap = new TreeMap();
+		backingMap.put(key, value);
+		PersistentSortedMap source = new PersistentSortedMap(session, backingMap);
+		
+		new CollectionConverterCompatibility1_9().marshal(source, writer, context, converterLookup);
+		
+		verify(converterLookup).lookupConverterForType(TreeMap.class);
+		verify(converter).marshal(argThat(hasEntry(key, value)),
+				same(writer), same(context));
+	}
+	
+	@Test
+	public void marshal_PersistentMap() {
+		Map backingMap = new HashMap();
+		backingMap.put(key, value);
+		PersistentMap source = new PersistentMap(session, backingMap);
+		
+		new CollectionConverterCompatibility1_9().marshal(source, writer, context, converterLookup);
+		
+		verify(converterLookup).lookupConverterForType(HashMap.class);
+		verify(converter).marshal(argThat(hasEntry(key, value)),
+				same(writer), same(context));
+	}
+	
+	@Test
+	public void marshal_PersistentSortedSet() {
+		SortedSet backingSet = new TreeSet();
+		backingSet.add(value);
+		PersistentSortedSet source =
+				new PersistentSortedSet(session, backingSet);
+		
+		new CollectionConverterCompatibility1_9().marshal(source, writer, context, converterLookup);
+		
+		verify(converterLookup).lookupConverterForType(TreeSet.class);
+		verify(converter).marshal(argThat(hasItem(value)),
+				same(writer), same(context));
+	}
+	
+	@Test
+	public void marshal_PersistentSet() {
+		Set backingSet = new HashSet();
+		backingSet.add(value);
+		PersistentSet source = new PersistentSet(session, backingSet);
+		
+		new CollectionConverterCompatibility1_9().marshal(source, writer, context, converterLookup);
+		
+		verify(converterLookup).lookupConverterForType(HashSet.class);
+		verify(converter).marshal(argThat(hasItem(value)),
+				same(writer), same(context));
+	}
+	
+	@Test
+	public void marshal_nonPersistentCollection() {
+		Set source = new HashSet();
+		source.add(value);
+		
+		new CollectionConverterCompatibility1_9().marshal(source, writer, context, converterLookup);
+		
+		verify(converterLookup).lookupConverterForType(HashSet.class);
+		verify(converter).marshal(same(source), same(writer), same(context));
+	}
+}


### PR DESCRIPTION
Hi team,

This is to fix the long-hanging bug [META-379](https://openmrs.atlassian.net/browse/META-379)
aka https://openmrs.atlassian.net/browse/META-377
aka https://openmrs.atlassian.net/browse/META-380
aka https://openmrs.atlassian.net/browse/META-381
(not sure why we have all those clones in Jira, but the bug is valid)

The existing conversion logic was not handling PersistentBag, PersistentIdentifierBag, and PersistentSortedMap correctly.
The fix will convert all PersistentCollection implementations correctly.

Added unit tests to validate the solution.

[META-379]: https://openmrs.atlassian.net/browse/META-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ